### PR TITLE
Change sprint input to match down-thrust input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.vs
+Owen013.MovementMod/obj


### PR DESCRIPTION
I changed the input to match. I also added two patches. The first one disables downward thrusting while sprinting until you release control and press it again. The second one makes it so that if you are holding control while in the air, you start sprinting again once you hit the ground.